### PR TITLE
Syntax error in Linux keymap

### DIFF
--- a/Default (Linux).sublime-keymap
+++ b/Default (Linux).sublime-keymap
@@ -1,4 +1,4 @@
-]
+[
     {
         "keys": ["ctrl+shift+d"], "command": "smart_duplicate"
     }


### PR DESCRIPTION
Inserted open instead of closed square bracket
